### PR TITLE
[Docs][CodeStructure] Resolve skeleton-linter findings in skeleton docs

### DIFF
--- a/docs/code_structure/data/structures/three_d/mesh/code_structure.md
+++ b/docs/code_structure/data/structures/three_d/mesh/code_structure.md
@@ -4,8 +4,10 @@ Code-structure skeleton for `data/structures/three_d/mesh/`.
 
 ## Mesh class
 
+`data/structures/three_d/mesh/mesh.py`
+
 ```text
-data/structures/three_d/mesh/mesh.py
+mesh.py
 ├── from data.structures.three_d.mesh.texture.mesh_texture import MeshTexture
 ├── from data.structures.three_d.mesh.validate import validate_mesh_attributes
 └── class Mesh
@@ -38,8 +40,10 @@ data/structures/three_d/mesh/mesh.py
 
 ## Geometry and linkage validation
 
+`data/structures/three_d/mesh/validate.py`
+
 ```text
-data/structures/three_d/mesh/validate.py
+validate.py
 ├── from data.structures.three_d.mesh.texture.mesh_texture_uv_texture_map import MeshTextureUVTextureMap
 ├── from data.structures.three_d.mesh.texture.mesh_texture_vertex_color import MeshTextureVertexColor
 ├── def validate_mesh_attributes(verts: torch.Tensor, faces: torch.Tensor, texture: Optional[MeshTexture] = None) -> None
@@ -58,8 +62,10 @@ data/structures/three_d/mesh/validate.py
 
 ## Texture: abstract base
 
+`data/structures/three_d/mesh/texture/mesh_texture.py`
+
 ```text
-data/structures/three_d/mesh/texture/mesh_texture.py
+mesh_texture.py
 ├── import abc
 └── class MeshTexture(abc.ABC)
     ├── # Abstract base for a mesh's texture; concrete subclasses own the representation-specific tensors and validation.
@@ -71,8 +77,10 @@ data/structures/three_d/mesh/texture/mesh_texture.py
 
 ## Texture: vertex-color representation
 
+`data/structures/three_d/mesh/texture/mesh_texture_vertex_color.py`
+
 ```text
-data/structures/three_d/mesh/texture/mesh_texture_vertex_color.py
+mesh_texture_vertex_color.py
 ├── from data.structures.three_d.mesh.texture.mesh_texture import MeshTexture
 ├── from data.structures.three_d.mesh.texture.validate_vertex_color import validate_vertex_color
 └── class MeshTextureVertexColor(MeshTexture)
@@ -94,8 +102,10 @@ data/structures/three_d/mesh/texture/mesh_texture_vertex_color.py
 
 ## Texture: uv-texture-map representation
 
+`data/structures/three_d/mesh/texture/mesh_texture_uv_texture_map.py`
+
 ```text
-data/structures/three_d/mesh/texture/mesh_texture_uv_texture_map.py
+mesh_texture_uv_texture_map.py
 ├── from data.structures.three_d.mesh.texture.conventions import transform_verts_uvs_convention
 ├── from data.structures.three_d.mesh.texture.mesh_texture import MeshTexture
 ├── from data.structures.three_d.mesh.texture.validate_uv_texture_map import validate_uv_texture_map
@@ -125,8 +135,10 @@ data/structures/three_d/mesh/texture/mesh_texture_uv_texture_map.py
 
 ## Texture: UV-origin convention
 
+`data/structures/three_d/mesh/texture/conventions.py`
+
 ```text
-data/structures/three_d/mesh/texture/conventions.py
+conventions.py
 └── def transform_verts_uvs_convention(verts_uvs: torch.Tensor, source_convention: str, target_convention: str) -> torch.Tensor
     ├── # Transforms a UV table between origin conventions ("obj" = v from bottom, "top_left" = v from top).
     ├── if source_convention == target_convention
@@ -138,8 +150,10 @@ data/structures/three_d/mesh/texture/conventions.py
 
 ## Texture: seam-safe canonical layout
 
+`data/structures/three_d/mesh/texture/canonicalize.py`
+
 ```text
-data/structures/three_d/mesh/texture/canonicalize.py
+canonicalize.py
 ├── def shift_seam_crossing_faces_to_seam_safe(verts_uvs: torch.Tensor, faces_uvs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]
 │   ├── # Shifts seam-crossing UV faces into the seam-safe canonical chart (each face's corners made contiguous: its largest cyclic gap is the wraparound gap), forking any source vt row shared between a shifted and a non-shifted face.
 │   ├── impls for each face, sort its 3 corner-u's and find the largest cyclic gap among the two interior gaps and the wraparound gap (min_u + 1 - max_u)
@@ -157,8 +171,10 @@ data/structures/three_d/mesh/texture/canonicalize.py
 
 ## Texture: vertex-color validation
 
+`data/structures/three_d/mesh/texture/validate_vertex_color.py`
+
 ```text
-data/structures/three_d/mesh/texture/validate_vertex_color.py
+validate_vertex_color.py
 ├── def validate_vertex_color(obj: Any) -> None
 │   ├── # Validates a vertex-color tensor ([V,3] or [1,V,3]; uint8 [0,255] or float32 [0,1]).
 │   ├── if obj.dtype == torch.uint8
@@ -176,8 +192,10 @@ data/structures/three_d/mesh/texture/validate_vertex_color.py
 
 ## Texture: uv-texture-map validation
 
+`data/structures/three_d/mesh/texture/validate_uv_texture_map.py`
+
 ```text
-data/structures/three_d/mesh/texture/validate_uv_texture_map.py
+validate_uv_texture_map.py
 ├── def validate_uv_texture_map(uv_texture_map: torch.Tensor, verts_uvs: torch.Tensor, faces_uvs: torch.Tensor, convention: str) -> None
 │   ├── # Validates the whole uv-texture-map representation: every single-field validator plus the cross-field invariants.
 │   ├── calls validate_uv_texture_map_image                  # single-field: uv_texture_map
@@ -218,8 +236,10 @@ data/structures/three_d/mesh/texture/validate_uv_texture_map.py
 
 ## Texture: texel-to-face map
 
+`data/structures/three_d/mesh/texture/texel_face_map.py`
+
 ```text
-data/structures/three_d/mesh/texture/texel_face_map.py
+texel_face_map.py
 ├── import nvdiffrast.torch as dr
 ├── from data.structures.three_d.mesh.texture.mesh_texture_uv_texture_map import MeshTextureUVTextureMap
 ├── if TYPE_CHECKING
@@ -250,8 +270,10 @@ data/structures/three_d/mesh/texture/texel_face_map.py
 
 ## Texture: package API surface
 
+`data/structures/three_d/mesh/texture/__init__.py`
+
 ```text
-data/structures/three_d/mesh/texture/__init__.py
+__init__.py
 ├── from data.structures.three_d.mesh.texture.canonicalize import collapse_seam_shifted_uv_rows, shift_seam_crossing_faces_to_seam_safe
 ├── from data.structures.three_d.mesh.texture.conventions import transform_verts_uvs_convention
 ├── from data.structures.three_d.mesh.texture.mesh_texture import MeshTexture
@@ -264,13 +286,17 @@ data/structures/three_d/mesh/texture/__init__.py
 
 ## Loading: API and format dispatch
 
+`data/structures/three_d/mesh/load/__init__.py`
+
 ```text
-data/structures/three_d/mesh/load/__init__.py
+__init__.py
 └── from data.structures.three_d.mesh.load.load import load_mesh
 ```
 
+`data/structures/three_d/mesh/load/load.py`
+
 ```text
-data/structures/three_d/mesh/load/load.py
+load.py
 ├── from data.structures.three_d.mesh.load.load_glb import load_glb_mesh
 ├── from data.structures.three_d.mesh.load.load_obj import load_obj_mesh
 └── def load_mesh(path: Union[str, Path]) -> Mesh
@@ -286,8 +312,10 @@ data/structures/three_d/mesh/load/load.py
 
 ## Loading: OBJ
 
+`data/structures/three_d/mesh/load/load_obj.py`
+
 ```text
-data/structures/three_d/mesh/load/load_obj.py
+load_obj.py
 ├── from pytorch3d.io import load_obj
 ├── from data.structures.three_d.mesh.load.merge import merge_meshes, pack_texture_images
 ├── from data.structures.three_d.mesh.mesh import Mesh
@@ -335,8 +363,10 @@ data/structures/three_d/mesh/load/load_obj.py
 
 ## Loading: GLB
 
+`data/structures/three_d/mesh/load/load_glb.py`
+
 ```text
-data/structures/three_d/mesh/load/load_glb.py
+load_glb.py
 ├── import numpy as np
 ├── import torch
 ├── from data.structures.three_d.mesh.mesh import Mesh
@@ -383,8 +413,10 @@ data/structures/three_d/mesh/load/load_glb.py
 
 ## Loading: block merging
 
+`data/structures/three_d/mesh/load/merge.py`
+
 ```text
-data/structures/three_d/mesh/load/merge.py
+merge.py
 ├── from data.structures.three_d.mesh.mesh import Mesh
 ├── from data.structures.three_d.mesh.texture.mesh_texture_uv_texture_map import MeshTextureUVTextureMap
 ├── from data.structures.three_d.mesh.texture.mesh_texture_vertex_color import MeshTextureVertexColor
@@ -421,13 +453,17 @@ data/structures/three_d/mesh/load/merge.py
 
 ## Saving: API and format dispatch
 
+`data/structures/three_d/mesh/save/__init__.py`
+
 ```text
-data/structures/three_d/mesh/save/__init__.py
+__init__.py
 └── from data.structures.three_d.mesh.save.save import save_mesh
 ```
 
+`data/structures/three_d/mesh/save/save.py`
+
 ```text
-data/structures/three_d/mesh/save/save.py
+save.py
 ├── from data.structures.three_d.mesh.mesh import Mesh
 ├── from data.structures.three_d.mesh.save.save_glb import save_glb_mesh
 ├── from data.structures.three_d.mesh.save.save_obj import save_obj_mesh
@@ -448,8 +484,10 @@ data/structures/three_d/mesh/save/save.py
 
 ## Saving: OBJ
 
+`data/structures/three_d/mesh/save/save_obj.py`
+
 ```text
-data/structures/three_d/mesh/save/save_obj.py
+save_obj.py
 ├── from data.structures.three_d.mesh.mesh import Mesh
 ├── from data.structures.three_d.mesh.texture.canonicalize import collapse_seam_shifted_uv_rows
 ├── from data.structures.three_d.mesh.texture.conventions import transform_verts_uvs_convention
@@ -488,8 +526,10 @@ data/structures/three_d/mesh/save/save_obj.py
 
 ## Saving: PLY
 
+`data/structures/three_d/mesh/save/save_ply.py`
+
 ```text
-data/structures/three_d/mesh/save/save_ply.py
+save_ply.py
 ├── from data.structures.three_d.mesh.mesh import Mesh
 ├── from data.structures.three_d.mesh.texture.mesh_texture_uv_texture_map import MeshTextureUVTextureMap
 ├── from data.structures.three_d.mesh.texture.mesh_texture_vertex_color import MeshTextureVertexColor
@@ -518,8 +558,10 @@ data/structures/three_d/mesh/save/save_ply.py
 
 ## Saving: GLB
 
+`data/structures/three_d/mesh/save/save_glb.py`
+
 ```text
-data/structures/three_d/mesh/save/save_glb.py
+save_glb.py
 ├── import numpy as np
 ├── import torch
 ├── from data.structures.three_d.mesh.mesh import Mesh
@@ -562,8 +604,10 @@ data/structures/three_d/mesh/save/save_glb.py
 
 ## Framework interop conversions
 
+`data/structures/three_d/mesh/convert.py`
+
 ```text
-data/structures/three_d/mesh/convert.py
+convert.py
 ├── from data.structures.three_d.mesh.mesh import Mesh
 ├── from data.structures.three_d.mesh.texture.canonicalize import collapse_seam_shifted_uv_rows, shift_seam_crossing_faces_to_seam_safe
 ├── from data.structures.three_d.mesh.texture.mesh_texture_uv_texture_map import MeshTextureUVTextureMap
@@ -630,8 +674,10 @@ data/structures/three_d/mesh/convert.py
 
 ## Package API surface
 
+`data/structures/three_d/mesh/__init__.py`
+
 ```text
-data/structures/three_d/mesh/__init__.py
+__init__.py
 ├── from data.structures.three_d.mesh import texture
 ├── from data.structures.three_d.mesh.convert import mesh_from_open3d, mesh_from_pytorch3d, mesh_from_trimesh, mesh_to_open3d, mesh_to_pytorch3d, mesh_to_trimesh
 ├── from data.structures.three_d.mesh.load import load_mesh

--- a/docs/code_structure/data/structures/three_d/mesh/tests_structure.md
+++ b/docs/code_structure/data/structures/three_d/mesh/tests_structure.md
@@ -19,8 +19,10 @@ tests/data/structures/three_d/mesh/
 
 ## 2. Code structure trees
 
+`tests/data/structures/three_d/mesh/test_convert.py`
+
 ```text
-tests/data/structures/three_d/mesh/test_convert.py
+test_convert.py
 ├── def test_mesh_from_trimesh_welds_seam_to_geometry_domain
 │   └── # A seamed UV mesh that trimesh loads in per-corner-expanded form (V == U) must come through mesh_from_trimesh on the canonical geometry domain (V <= U, distinct positions), with the seam carried only by verts_uvs / faces_uvs. Enforces the seam contract (task.md design.2).
 ├── def test_vertex_count_is_loader_independent
@@ -33,16 +35,20 @@ tests/data/structures/three_d/mesh/test_convert.py
     └── # mesh_to_open3d then mesh_from_open3d must preserve geometry and vertex colors (the Open3D path carries no UV texture).
 ```
 
+`tests/data/structures/three_d/mesh/texture/test_conventions.py`
+
 ```text
-tests/data/structures/three_d/mesh/texture/test_conventions.py
+test_conventions.py
 ├── def test_identity_when_conventions_match
 │   └── # transform_verts_uvs_convention returns the UV table unchanged when the source and target conventions are equal.
 └── def test_flips_v_axis_when_conventions_differ
     └── # transform_verts_uvs_convention flips the V axis (v -> 1 - v) when the source and target conventions differ.
 ```
 
+`tests/data/structures/three_d/mesh/texture/test_mesh_texture_vertex_color.py`
+
 ```text
-tests/data/structures/three_d/mesh/texture/test_mesh_texture_vertex_color.py
+test_mesh_texture_vertex_color.py
 ├── def test_normalizes_uint8_to_float01
 │   └── # MeshTextureVertexColor normalizes a uint8 [0,255] vertex_color into contiguous float32 [V,3] in [0,1].
 ├── def test_rejects_out_of_range_float
@@ -51,8 +57,10 @@ tests/data/structures/three_d/mesh/texture/test_mesh_texture_vertex_color.py
     └── # MeshTextureVertexColor.to raises when given a non-None convention, since vertex color carries no UV convention.
 ```
 
+`tests/data/structures/three_d/mesh/texture/test_mesh_texture_uv_texture_map.py`
+
 ```text
-tests/data/structures/three_d/mesh/texture/test_mesh_texture_uv_texture_map.py
+test_mesh_texture_uv_texture_map.py
 ├── def test_rejects_faces_uvs_index_out_of_range
 │   └── # MeshTextureUVTextureMap rejects faces_uvs whose indices do not reference valid verts_uvs rows (the cross-field invariant).
 ├── def test_normalizes_uint8_texture_map
@@ -67,8 +75,10 @@ tests/data/structures/three_d/mesh/texture/test_mesh_texture_uv_texture_map.py
     └── # MeshTextureUVTextureMap.to(convention=...) returns a texture whose verts_uvs is converted to the target UV-origin convention.
 ```
 
+`tests/data/structures/three_d/mesh/texture/test_texel_face_map.py`
+
 ```text
-tests/data/structures/three_d/mesh/texture/test_texel_face_map.py
+test_texel_face_map.py
 ├── def test_build_texel_face_map_returns_texel_face_index_and_barycentric
 │   └── # build_texel_face_map returns texel_face_index [T, T] int64 and texel_face_barycentric [T, T, 3] float32 with the expected shapes and -1 / NaN sentinels at unoccupied texels.
 ├── def test_build_texel_face_map_maps_identity_face_to_top_row
@@ -79,8 +89,10 @@ tests/data/structures/three_d/mesh/texture/test_texel_face_map.py
     └── # gather(face_attr[faces[texel_face_index]] * texel_face_barycentric).sum(...) recovers a per-vertex attribute on every occupied texel within numerical tolerance.
 ```
 
+`tests/data/structures/three_d/mesh/test_load_save_roundtrip.py`
+
 ```text
-tests/data/structures/three_d/mesh/test_load_save_roundtrip.py
+test_load_save_roundtrip.py
 ├── def test_load_save_obj_with_seam_face_is_byte_identical
 │   └── # Load a hand-written seamed UV OBJ, save it back, and assert byte equality of the resulting vt / f lines — exercises the seam-shift-at-load + collapse-on-save round-trip.
 ├── def test_load_promotes_seam_crossing_face_to_seam_safe_canonical

--- a/docs/code_structure/data/viewer/code_structure.md
+++ b/docs/code_structure/data/viewer/code_structure.md
@@ -462,7 +462,6 @@ core_points_display.ts
 
 ```text
 apis.py
-├── from typing import Optional
 ├── import torch
 ├── from dash import dcc
 ├── from data.viewer.utils.atomic_displays.pixels.dash.core_pixels_display import create_dash_pixels_display
@@ -577,7 +576,6 @@ display_response.py
 
 ```text
 apis.py
-├── from typing import Any, Dict, Tuple
 ├── import torch
 ├── from data.viewer.utils.atomic_displays.pixels.ts.backend.core_pixels_display import create_pixels_display_response
 ├── from data.viewer.utils.atomic_displays.utils.class_colors import map_class_ids_to_rgb
@@ -1156,7 +1154,7 @@ apis.py
 
 ```text
 core_mesh_display.py
-├── from typing import Any, Dict, Optional
+├── from typing import Any, Optional
 ├── import plotly.graph_objects as go
 ├── from dash import dcc
 ├── from data.viewer.utils.camera_controls.dash.trackball_camera_controls import create_dash_trackball_camera_controls
@@ -1519,7 +1517,6 @@ display_response.py
 
 ```text
 apis.py
-├── from typing import Any, Dict, Tuple
 ├── import torch
 ├── from data.viewer.utils.atomic_displays.gaussians.ts.backend.core_gaussians_display import create_gaussians_display_response
 ├── from data.viewer.utils.atomic_displays.utils.class_colors import map_class_ids_to_rgb
@@ -1865,7 +1862,6 @@ trackball_camera_controls.ts
 
 ```text
 camera_sync.py
-├── from data.viewer.utils.camera_state.dash.camera_state import CameraState
 ├── def create_camera_sync_store
 │   ├── # Creates the Dash store that holds the per-source camera-sync registry keyed by source id.
 │   ├── impls creates Dash store holding a mapping from source id to its CameraSyncState entry (source id, target ids, current camera state)
@@ -1895,7 +1891,6 @@ camera_sync.py
 
 ```text
 types.ts
-├── import type { CameraState } from "data/viewer/utils/camera_state/ts/frontend/types";
 └── interface CameraSyncState
     ├── source_id    # the source this entry belongs to; one CameraSyncState exists per source
     ├── target_ids   # targets registered under this source

--- a/docs/code_structure/models/mesh/code_structure.md
+++ b/docs/code_structure/models/mesh/code_structure.md
@@ -4,8 +4,10 @@ Code-structure skeleton for `models/three_d/meshes/texture/extract/`. `def` line
 
 ## 1. Code structure trees
 
+`models/three_d/meshes/texture/extract/camera_geometry.py`
+
 ```text
-models/three_d/meshes/texture/extract/camera_geometry.py
+camera_geometry.py
 ├── from data.structures.three_d.camera.cameras import Cameras
 ├── from data.structures.three_d.point_cloud.camera.transform import world_to_camera_transform
 ├── def render_camera_face_index_buffer(verts_camera: torch.Tensor, faces: torch.Tensor, intrinsics: torch.Tensor, image_height: int, image_width: int) -> torch.Tensor
@@ -24,8 +26,10 @@ models/three_d/meshes/texture/extract/camera_geometry.py
     └── calls world_to_camera_transform(points=verts, extrinsics=camera_single.extrinsics, inplace=False)
 ```
 
+`models/three_d/meshes/texture/extract/extract.py`
+
 ```text
-models/three_d/meshes/texture/extract/extract.py
+extract.py
 ├── from data.structures.three_d.camera.cameras import Cameras
 ├── from data.structures.three_d.mesh.mesh import Mesh
 ├── from data.structures.three_d.mesh.texture.texel_face_map import build_texel_face_map
@@ -38,6 +42,8 @@ models/three_d/meshes/texture/extract/extract.py
 ├── from models.three_d.meshes.texture.extract.weights.weights_cfg import normalize_weights_cfg, validate_weights_cfg
 ├── def extract_texture_from_images(mesh: Union[Mesh, List[Mesh]], images: Union[torch.Tensor, List[torch.Tensor]], cameras: Cameras, weights_cfg: Dict[str, Any]={}, texture_size: int=1024, default_color: float=0.7, return_valid_mask: bool=False, texel_visibility_method: str='v1', polygon_rast_method: str='v2') -> Union[torch.Tensor, Dict[str, torch.Tensor]]
 │   ├── # Extract texture from multi-view RGB images.
+│   ├── calls validate_weights_cfg(weights_cfg=weights_cfg)
+│   ├── calls normalize_weights_cfg(weights_cfg=weights_cfg)
 │   ├── if not extract_uv_texture_map
 │   │   └── calls _extract_vertex_color_from_images(meshes=meshes, images_nchw=images_nchw, cameras=cameras, weights_cfg=weights_cfg, default_color=default_color)
 │   └── calls _extract_uv_texture_map_from_images(meshes=meshes, images_nchw=images_nchw, cameras=cameras, weights_cfg=weights_cfg, texture_size=texture_size, default_color=default_color, texel_visibility_method=texel_visibility_method, polygon_rast_method=polygon_rast_method)
@@ -103,8 +109,10 @@ models/three_d/meshes/texture/extract/extract.py
     └── # Map per-face weights to per-UV-pixel weights for one view.
 ```
 
+`models/three_d/meshes/texture/extract/weights/normal_weights.py`
+
 ```text
-models/three_d/meshes/texture/extract/weights/normal_weights.py
+normal_weights.py
 ├── from data.structures.three_d.camera.cameras import Cameras
 ├── from data.structures.three_d.mesh.mesh import Mesh
 ├── from models.three_d.meshes.ops.normals import compute_vertex_normals
@@ -118,8 +126,10 @@ models/three_d/meshes/texture/extract/weights/normal_weights.py
     └── calls _verts_world_to_camera(verts=mesh.verts, camera=camera)
 ```
 
+`models/three_d/meshes/texture/extract/weights/weights_cfg.py`
+
 ```text
-models/three_d/meshes/texture/extract/weights/weights_cfg.py
+weights_cfg.py
 ├── WEIGHTS_CFG_ALLOWED_KEYS
 ├── def validate_weights_cfg(weights_cfg: Dict[str, Any]) -> None
 │   └── # Validate one texture-extraction weights config.
@@ -127,8 +137,10 @@ models/three_d/meshes/texture/extract/weights/weights_cfg.py
     └── # Normalize one texture-extraction weights config.
 ```
 
+`models/three_d/meshes/texture/extract/visibility/texel_visibility.py`
+
 ```text
-models/three_d/meshes/texture/extract/visibility/texel_visibility.py
+texel_visibility.py
 ├── from data.structures.three_d.camera.cameras import Cameras
 ├── from models.three_d.meshes.texture.extract.camera_geometry import _verts_world_to_camera
 ├── from models.three_d.meshes.texture.extract.weights.normal_weights import compute_f_normals_weights
@@ -215,8 +227,10 @@ models/three_d/meshes/texture/extract/visibility/texel_visibility.py
     └── calls build_uv_triangle_texel_intersections_v2(uv_triangles=wrapped_uv_triangles, texture_size=texture_size)
 ```
 
+`models/three_d/meshes/texture/extract/visibility/texel_visibility_geometry.py`
+
 ```text
-models/three_d/meshes/texture/extract/visibility/texel_visibility_geometry.py
+texel_visibility_geometry.py
 ├── TARGET_MULTI_FACE_PIXEL_SPLIT_LINE_BUDGET
 ├── def build_visible_face_pixel_polygons(clipped_polygon_verts: torch.Tensor, clipped_polygon_vertex_counts: torch.Tensor, clipped_pixel_indices: torch.Tensor, clipped_face_indices: torch.Tensor, face_inverse_depth_coefficients: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
 │   ├── # Build exact visible face-pixel polygons in batched tensor form.
@@ -325,8 +339,10 @@ models/three_d/meshes/texture/extract/visibility/texel_visibility_geometry.py
     └── # Compute 2D cross product magnitude.
 ```
 
+`models/three_d/meshes/texture/extract/visibility/texel_visibility_v2.py`
+
 ```text
-models/three_d/meshes/texture/extract/visibility/texel_visibility_v2.py
+texel_visibility_v2.py
 ├── from data.structures.three_d.camera.cameras import Cameras
 ├── from data.structures.three_d.point_cloud.camera.project import project_3d_to_2d
 ├── from data.structures.three_d.point_cloud.camera.transform import world_to_camera_transform
@@ -372,8 +388,10 @@ models/three_d/meshes/texture/extract/visibility/texel_visibility_v2.py
     └── # Derive the front-depth stopping threshold from the gap distribution.
 ```
 
+`models/three_d/meshes/texture/extract/visibility/vertex_visibility.py`
+
 ```text
-models/three_d/meshes/texture/extract/visibility/vertex_visibility.py
+vertex_visibility.py
 ├── from data.structures.three_d.camera.cameras import Cameras
 ├── from data.structures.three_d.mesh.mesh import Mesh
 ├── from models.three_d.meshes.texture.extract.camera_geometry import project_verts_to_image, render_camera_face_index_buffer

--- a/docs/code_structure/models/mesh/tests_structure.md
+++ b/docs/code_structure/models/mesh/tests_structure.md
@@ -15,8 +15,10 @@ tests/models/three_d/meshes/texture/
 
 ## 2. Code structure trees
 
+`tests/models/three_d/meshes/texture/test_extract.py`
+
 ```text
-tests/models/three_d/meshes/texture/test_extract.py
+test_extract.py
 ├── def test_compute_f_visibility_mask_keeps_uv_channel_dimension() -> None
 │   ├── # compute_f_visibility_mask keeps UV visibility masks in `[1, T, T, 1]` layout.
 │   └── calls _build_texel_face_map_stub
@@ -55,8 +57,10 @@ tests/models/three_d/meshes/texture/test_extract.py
     └── # extract_texture_from_images rejects noncanonical out-of-range float RGB images.
 ```
 
+`tests/models/three_d/meshes/texture/test_texel_visibility_v2.py`
+
 ```text
-tests/models/three_d/meshes/texture/test_texel_visibility_v2.py
+test_texel_visibility_v2.py
 ├── def test_compute_f_visibility_mask_v2_maps_texel_centers_through_identity_face() -> None
 │   ├── # compute_f_visibility_mask_v2 keeps the texel-center pipeline consistent on one identity face.
 │   ├── calls _build_one_camera
@@ -84,8 +88,10 @@ tests/models/three_d/meshes/texture/test_texel_visibility_v2.py
     └── # Build one identity OpenCV CPU camera for the focused v2 visibility tests.
 ```
 
+`tests/models/three_d/meshes/texture/test_vertex_visibility.py`
+
 ```text
-tests/models/three_d/meshes/texture/test_vertex_visibility.py
+test_vertex_visibility.py
 ├── def test_compute_v_visibility_mask_keeps_some_front_facing_triangle_visibility() -> None
 │   ├── # compute_v_visibility_mask keeps nonzero visibility when the only face is front-facing.
 │   └── calls _build_one_camera

--- a/docs/code_structure/utils/io/code_structure.md
+++ b/docs/code_structure/utils/io/code_structure.md
@@ -4,8 +4,10 @@ Code-structure skeleton for `utils/io/glb.py` and `utils/io/image.py`.
 
 ## glTF/GLB I/O
 
+`utils/io/glb.py`
+
 ```text
-utils/io/glb.py
+glb.py
 ├── import json
 ├── import struct
 ├── import numpy as np
@@ -44,8 +46,10 @@ utils/io/glb.py
 
 ## Image: in-memory bytes codec
 
+`utils/io/image.py`
+
 ```text
-utils/io/image.py
+image.py
 ├── def decode_image_bytes(image_bytes: bytes) -> torch.Tensor
 │   └── # Decodes encoded image bytes (PNG / JPEG / ...) into an HWC uint8 RGB tensor — in-memory counterpart of the file-based load_image.
 └── def encode_image_bytes(image: torch.Tensor, image_format: str) -> bytes


### PR DESCRIPTION
…

Migrate the affected lib code-structure units to the file-unit header + basename-root format and clear dangling imports, resolving the file-unit-header-and-root and no-unused-imports self-checks for these six files. Extracted from the sthetic-face linter-resolution branch; project-scoped doc fixes stay in the fork.